### PR TITLE
modules/account/form: increase size of mini resume field

### DIFF
--- a/app/modules/Account/form.html
+++ b/app/modules/Account/form.html
@@ -117,7 +117,7 @@
       <label>
         <span translate>mini-currículo</span>
       </label>
-      <textarea required minlength="5" maxlength="80" ng-model="signup.resume"></textarea>
+      <textarea required minlength="5" maxlength="400" ng-model="signup.resume"></textarea>
       <i class="fa fa-check"></i>
     </p>
 


### PR DESCRIPTION
It was increase in a582e5cfa2be3e71adfbbbd3e24d865a614c64d9 for the signup form, but the update form still limited the size of the field to 80 characters.

Fix #2.
